### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "progress": "1.1.7",
     "prompt": "0.2.12",
     "q": "1.0.1",
-    "request": "2.51.0",
+    "request": "2.74.0",
     "semver": "4.3.6",
     "serve-static": "1.7.1",
     "shelljs": "0.2.6",


### PR DESCRIPTION
ionic-cli currently has a 40 vulnerable dependency paths, introducing 14 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/driftyco/ionic-cli) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)